### PR TITLE
feat: pricing config + feature flags for fork enablement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,12 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 # Keep a "Built with 20xDev" credit badge in the footer (forks): set to 1.
 # NEXT_PUBLIC_BRAND_ATTRIBUTION=0
 
+# Feature flags — hide marketing surfaces cleanly (default on). Set to 0 to
+# drop the nav/footer entry AND 404 the route. See docs/rebranding.md.
+# NEXT_PUBLIC_FEATURE_MARKETING_SITE=1
+# NEXT_PUBLIC_FEATURE_BLOG=1
+# NEXT_PUBLIC_FEATURE_STUDIO=1
+
 # Convex
 NEXT_PUBLIC_CONVEX_URL=
 CONVEX_DEPLOY_KEY=

--- a/docs/rebranding.md
+++ b/docs/rebranding.md
@@ -41,10 +41,29 @@ The "Built with 20xDev" badge is a discrete component
 `NEXT_PUBLIC_BRAND_ATTRIBUTION=1`; the badge renders once in the footer and is the
 only place the upstream name appears.
 
+## 4. Hide marketing surfaces (feature flags)
+
+`siteConfig.features` lets a fork drop surfaces it doesn't ship, cleanly — the
+nav/footer entry disappears (no dangling links) and the route itself 404s. All
+default **on**, so 20xdev's own site is unchanged.
+
+| Env var | Effect | Default |
+|---|---|---|
+| `NEXT_PUBLIC_FEATURE_BLOG` | `=0` removes Blog nav + 404s `/blog` (and skips Sanity at build) | on |
+| `NEXT_PUBLIC_FEATURE_STUDIO` | `=0` 404s `/studio` | on |
+| `NEXT_PUBLIC_FEATURE_MARKETING_SITE` | flag for a fork that overrides `/` with its own landing | on |
+
+## 5. Pricing as config
+
+The pricing offer lives in `src/config/pricing.ts` (`pricingConfig` / `featuredPlan`):
+price, period, inclusions, and CTAs. The pricing page renders from it, so changing
+the offer (or scripting it) is a config edit, not a JSX edit. The shape is a
+`plans[]` array so it also supports multiple recurring tiers later.
+
 ## What this does NOT cover yet (follow-ups)
 
 - Landing marketing copy (`(landing)/about`, `features-section`, `contact`) still
   carries inline brand text — a future PR could route it through a `landingContent`
   config so the copy is one file.
-- Optional `features.marketingBlog` / `features.studio` flags to hide the blog and
-  Sanity studio route groups cleanly (instead of deleting them).
+- Graceful degradation for optional integrations (Maps, Cal.com, Resend, OpenAI,
+  PostHog) when their env is unset, so a minimal fork runs on auth + Convex only.

--- a/src/app/(landing)/blog/[slug]/page.tsx
+++ b/src/app/(landing)/blog/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { JsonLd } from '../_components/json-ld';
 import type { Post } from '@/types/blog';
 import type { Metadata } from 'next';
 
+import { siteConfig } from '@/config/site';
 import { client } from '@/sanity/lib/client';
 import { urlForImage } from '@/sanity/lib/image';
 import { getPostBySlugQuery, getPostSlugsQuery } from '@/sanity/lib/queries';
@@ -19,6 +20,7 @@ interface PostPageProps {
 }
 
 export async function generateStaticParams(): Promise<{ slug: string }[]> {
+  if (!siteConfig.features.blog) return [];
   try {
     const slugs = await client.fetch<string[]>(getPostSlugsQuery);
     return slugs.map((slug) => ({ slug }));
@@ -60,6 +62,8 @@ export async function generateMetadata({ params }: PostPageProps): Promise<Metad
 }
 
 export default async function PostPage({ params }: PostPageProps): Promise<React.ReactElement> {
+  if (!siteConfig.features.blog) notFound();
+
   const { slug } = await params;
 
   const post = await client.fetch<Post | null>(

--- a/src/app/(landing)/blog/category/[slug]/page.tsx
+++ b/src/app/(landing)/blog/category/[slug]/page.tsx
@@ -9,6 +9,7 @@ import { CategoryFilter } from '../../_components/category-filter';
 import type { Category, PostListItem } from '@/types/blog';
 import type { Metadata } from 'next';
 
+import { siteConfig } from '@/config/site';
 import { client } from '@/sanity/lib/client';
 import {
   getCategoriesQuery,
@@ -21,6 +22,7 @@ interface CategoryPageProps {
 }
 
 export async function generateStaticParams(): Promise<{ slug: string }[]> {
+  if (!siteConfig.features.blog) return [];
   try {
     const slugs = await client.fetch<string[]>(getCategorySlugsQuery);
     return slugs.map((slug) => ({ slug }));
@@ -53,6 +55,8 @@ export async function generateMetadata({ params }: CategoryPageProps): Promise<M
 export default async function CategoryPage({
   params,
 }: CategoryPageProps): Promise<React.ReactElement> {
+  if (!siteConfig.features.blog) notFound();
+
   const { slug } = await params;
 
   const [posts, categories] = await Promise.all([

--- a/src/app/(landing)/blog/page.tsx
+++ b/src/app/(landing)/blog/page.tsx
@@ -1,6 +1,6 @@
 import { T } from 'gt-next';
 import { FileText } from 'lucide-react';
-import { redirect } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 
 import { BlogGrid } from './_components/blog-grid';
 import { BlogHeader } from './_components/blog-header';
@@ -53,6 +53,8 @@ async function getBlogPageData(offset: number): Promise<{
 export default async function BlogPage({
   searchParams,
 }: BlogPageProps): Promise<React.ReactElement> {
+  if (!siteConfig.features.blog) notFound();
+
   const params = await searchParams;
   const parsedPage = Number(params.page);
   const currentPage = Number.isInteger(parsedPage) && parsedPage > 0 ? parsedPage : 1;

--- a/src/app/(landing)/pricing/page.tsx
+++ b/src/app/(landing)/pricing/page.tsx
@@ -5,20 +5,14 @@ import Link from 'next/link';
 import type { Metadata } from 'next';
 
 import { Button } from '@/components/ui/button';
+import { pricingConfig, featuredPlan } from '@/config/pricing';
 import { siteConfig } from '@/config/site';
 
 const heroLandscape = '/images/website/background.avif';
 
-const inclusions = [
-  'Full source code for the starter',
-  'Auth, organizations, dashboard, files, and billing foundations',
-  'Built-in stack for shipping B2B SaaS faster',
-  'One-time payment, no subscription',
-] as const;
-
 export const metadata: Metadata = {
   title: `Pricing - ${siteConfig.name}`,
-  description: `Temporary pricing for ${siteConfig.name}: lifetime deal access for 79€.`,
+  description: `Temporary pricing for ${siteConfig.name}: lifetime deal access for ${featuredPlan.priceLabel}.`,
 };
 
 export default function PricingPage(): React.ReactElement {
@@ -30,12 +24,12 @@ export default function PricingPage(): React.ReactElement {
         <div className="mx-auto flex max-w-5xl flex-col gap-12 lg:gap-16">
           <header className="mx-auto max-w-[44rem] text-center">
             <div className="inline-flex items-center rounded-full border border-[#d9cebf] bg-[rgba(255,255,255,0.72)] px-4 py-1.5 text-[0.82rem] font-medium tracking-[0.01em] text-[#5f5751] shadow-[0_10px_30px_rgba(45,32,50,0.06)] backdrop-blur-sm">
-              Temporary pricing
+              {pricingConfig.badge}
             </div>
             <h1 className="mt-6 text-[clamp(3rem,7vw,4.7rem)] leading-[0.94] font-normal tracking-[-0.07em] text-[#222221]">
               One lifetime deal.
               <br />
-              79€ and you are in.
+              {featuredPlan.priceLabel} and you are in.
             </h1>
             <p className="mx-auto mt-5 max-w-[36rem] text-[1.05rem] leading-7 tracking-[-0.03em] text-[#5f5751]/90 sm:text-[1.16rem]">
               For now, {siteConfig.name} is available as a simple one-time purchase. No tiers, no
@@ -48,14 +42,14 @@ export default function PricingPage(): React.ReactElement {
               <div className="flex flex-col gap-8">
                 <div className="flex flex-col gap-4 border-b border-[#e2d9ce] pb-7">
                   <p className="text-[0.82rem] font-medium tracking-[0.08em] text-[#7c7068] uppercase">
-                    Lifetime access
+                    {featuredPlan.label}
                   </p>
                   <div className="flex flex-wrap items-end gap-3">
                     <div className="text-[clamp(3.8rem,9vw,5.6rem)] leading-none font-normal tracking-[-0.08em] text-[#1e1916]">
-                      79€
+                      {featuredPlan.priceLabel}
                     </div>
                     <p className="pb-2 text-[1rem] leading-7 tracking-[-0.02em] text-[#6b615a]">
-                      one-time payment
+                      {featuredPlan.period}
                     </p>
                   </div>
                   <p className="max-w-[34rem] text-[1rem] leading-7 tracking-[-0.025em] text-[#5f5751]/90">
@@ -66,7 +60,7 @@ export default function PricingPage(): React.ReactElement {
                 </div>
 
                 <div className="grid gap-4 sm:grid-cols-2">
-                  {inclusions.map((item) => (
+                  {featuredPlan.inclusions.map((item) => (
                     <div
                       key={item}
                       className="flex items-start gap-3 rounded-[1.4rem] border border-[#e7dfd5] bg-[rgba(247,241,231,0.7)] px-4 py-4"
@@ -103,18 +97,22 @@ export default function PricingPage(): React.ReactElement {
                     asChild
                     className="h-12 w-full rounded-full bg-white px-6 text-[0.98rem] font-medium tracking-[-0.02em] text-[#1a1411] shadow-none hover:bg-white/92 hover:text-[#1a1411] [a]:hover:bg-white/92 [a]:hover:text-[#1a1411]"
                   >
-                    <Link href="/contact">
-                      Get the 79€ deal
+                    <Link href={featuredPlan.primaryCta.href}>
+                      {featuredPlan.primaryCta.label}
                       <ArrowRight className="size-4" />
                     </Link>
                   </Button>
-                  <Button
-                    asChild
-                    variant="outline"
-                    className="h-12 w-full rounded-full border-white/14 bg-white/6 px-6 text-[0.98rem] font-medium tracking-[-0.02em] text-white hover:bg-white/10 hover:text-white"
-                  >
-                    <Link href="/login">Open the product</Link>
-                  </Button>
+                  {featuredPlan.secondaryCta ? (
+                    <Button
+                      asChild
+                      variant="outline"
+                      className="h-12 w-full rounded-full border-white/14 bg-white/6 px-6 text-[0.98rem] font-medium tracking-[-0.02em] text-white hover:bg-white/10 hover:text-white"
+                    >
+                      <Link href={featuredPlan.secondaryCta.href}>
+                        {featuredPlan.secondaryCta.label}
+                      </Link>
+                    </Button>
+                  ) : null}
                 </div>
               </div>
             </aside>

--- a/src/app/studio/[[...tool]]/page.tsx
+++ b/src/app/studio/[[...tool]]/page.tsx
@@ -1,9 +1,13 @@
 'use client';
 
+import { notFound } from 'next/navigation';
 import { NextStudio } from 'next-sanity/studio';
 
+import { siteConfig } from '@/config/site';
 import config from '@/sanity/sanity.config';
 
 export default function StudioPage(): React.ReactElement {
+  if (!siteConfig.features.studio) notFound();
+
   return <NextStudio config={config} />;
 }

--- a/src/config/pricing.ts
+++ b/src/config/pricing.ts
@@ -1,0 +1,51 @@
+/**
+ * Pricing Configuration
+ *
+ * Data-driven pricing so a fork (or automation) can change the offer without
+ * editing the pricing page JSX. Defaults preserve the current 20xdev launch
+ * deal exactly. Shaped as a `plans` array so it can represent either a single
+ * one-time deal (current) or multiple recurring tiers later.
+ */
+
+export interface PricingCta {
+  readonly label: string;
+  readonly href: string;
+}
+
+export interface PricingPlan {
+  readonly id: string;
+  readonly label: string;
+  readonly priceLabel: string;
+  readonly period: string;
+  readonly inclusions: readonly string[];
+  readonly primaryCta: PricingCta;
+  readonly secondaryCta?: PricingCta;
+}
+
+export interface PricingConfig {
+  readonly badge: string;
+  readonly plans: readonly PricingPlan[];
+}
+
+const lifetimePlan: PricingPlan = {
+  id: 'lifetime',
+  label: 'Lifetime access',
+  priceLabel: '79€',
+  period: 'one-time payment',
+  inclusions: [
+    'Full source code for the starter',
+    'Auth, organizations, dashboard, files, and billing foundations',
+    'Built-in stack for shipping B2B SaaS faster',
+    'One-time payment, no subscription',
+  ],
+  primaryCta: { label: 'Get the 79€ deal', href: '/contact' },
+  secondaryCta: { label: 'Open the product', href: '/login' },
+};
+
+export const pricingConfig: PricingConfig = {
+  badge: 'Temporary pricing',
+  plans: [lifetimePlan],
+};
+
+/** The plan rendered as the headline offer. */
+export const featuredPlan: PricingPlan = lifetimePlan;

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -30,17 +30,25 @@ function featureLinks(titles: readonly string[]): readonly SiteLink[] {
 const socialGithub = process.env.NEXT_PUBLIC_BRAND_GITHUB ?? 'https://github.com/20xdev/20xdev';
 const socialTwitter = process.env.NEXT_PUBLIC_BRAND_TWITTER ?? 'https://twitter.com/20xdev';
 
-const mainNav = [
+// Feature flags — let a fork hide marketing surfaces cleanly. Default ON so
+// 20xdev's own site is unchanged; a fork sets NEXT_PUBLIC_FEATURE_*=0 to disable.
+// When a surface is off, its nav/footer entries are dropped here so there are no
+// dangling links, and the route itself 404s (see the route guards).
+const featureMarketingSite = process.env.NEXT_PUBLIC_FEATURE_MARKETING_SITE !== '0';
+const featureBlog = process.env.NEXT_PUBLIC_FEATURE_BLOG !== '0';
+const featureStudio = process.env.NEXT_PUBLIC_FEATURE_STUDIO !== '0';
+
+const mainNav: readonly SiteLink[] = [
   link('Pricing', '/pricing'),
-  link('Blog', '/blog'),
+  ...(featureBlog ? [link('Blog', '/blog')] : []),
   link('About', '/about'),
   link('Contact', '/contact'),
-] as const;
+];
 
 const footerColumns: readonly FooterColumn[] = [
   {
     title: 'Product',
-    links: [link('Dashboard', '/dashboard'), link('Blog', '/blog')],
+    links: [link('Dashboard', '/dashboard'), ...(featureBlog ? [link('Blog', '/blog')] : [])],
   },
   {
     title: 'Platform',
@@ -105,6 +113,13 @@ export const siteConfig = {
     enabled: process.env.NEXT_PUBLIC_BRAND_ATTRIBUTION === '1',
     label: 'Built with 20xDev',
     href: 'https://github.com/Carefully-Built/20xDev',
+  },
+
+  // Feature flags — read by route guards to 404 disabled marketing surfaces.
+  features: {
+    marketingSite: featureMarketingSite,
+    blog: featureBlog,
+    studio: featureStudio,
   },
 
   // Copyright


### PR DESCRIPTION
## What

Two small, additive, **backward-compatible** surfaces so a fork (or automation) can adapt 20xDev with **config instead of source edits**. Every default preserves the current site exactly — the demo renders identically until someone opts in.

Follow-up to #30 (configurable brand surface). Motivation is the same: we're building products on 20xDev as a base and want forking to be config-driven.

## 1. Pricing as config — `src/config/pricing.ts`

- Extracts the offer (price, period, inclusions, primary/secondary CTAs, badge) into a typed `pricingConfig` / `featuredPlan`. `(landing)/pricing/page.tsx` now renders from it — **same output**, styling untouched.
- Shaped as a `plans[]` array, so it represents the current single one-time deal today and can hold recurring tiers later without touching the page.

## 2. Feature flags — `siteConfig.features` (`NEXT_PUBLIC_FEATURE_*`)

- `marketingSite` / `blog` / `studio`, all **default on**.
- When a surface is off: its **nav/footer entry is dropped** (no dangling links) and the **route 404s**. `blog`'s `generateStaticParams` early-returns `[]` so a fork without Sanity env builds clean.

## Backward compatibility

All env vars optional; unset = current behavior. Nav, pricing output, and routes are byte-identical until a flag is set.

## Verification

- `bunx tsc --noEmit` → exit 0
- `eslint` on touched files → 0 errors (only pre-existing `max-lines` style warnings on the bespoke pricing page)
- Not run: full `next build` (needs Convex/WorkOS env) — happy to if useful.

## Deliberately out of scope (noted in docs/rebranding.md)

- Routing landing marketing copy through a `landingContent` config.
- Graceful degradation for optional integrations (Maps, Cal.com, Resend, OpenAI, PostHog) when their env is unset.

Flagging for review — glad to adjust naming/scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)