### PR TITLE
fix: exclude *.test.ts from convex/tsconfig.json (deploy typecheck parity)

### DIFF
--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -21,5 +21,8 @@
     "noEmit": true
   },
   "include": ["./**/*"],
-  "exclude": ["./_generated"]
+  /* Test files run under vitest (root tsconfig), not the Convex deploy typecheck.
+   * Excluding them here keeps `convex deploy`'s typecheck in parity with the
+   * project quality-gate, which already excludes convex/** and tests/**. */
+  "exclude": ["./_generated", "**/*.test.ts", "**/*.test.tsx"]
 }


### PR DESCRIPTION
convex/tsconfig.json includes every file under convex/, so `convex deploy`'s internal typecheck also checks *.test.ts files — which are meant for the project root tsconfig/vitest environment. A test-only type error (e.g. a TS2352 cast in a .test.ts) then blocks the deploy even though the project's own typecheck and build are green (this bit us on a downstream project).

Excluding `**/*.test.ts(x)` restores parity: convex deploy typechecks exactly the runtime code it ships; tests stay covered by the root toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5H8wb2p49xSSMgcHNh2m6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated type-checking configuration to exclude generated files and test files from Convex checks.
  * Added explanatory comments documenting the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->