### PR TITLE
feat: per-app WorkOS environment isolation for organizations

### DIFF
--- a/convex/functions/organizations/mutations.ts
+++ b/convex/functions/organizations/mutations.ts
@@ -2,6 +2,27 @@ import { v } from 'convex/values';
 
 import { mutation } from '../../_generated/server';
 
+// Per-app environment isolation guard. The Convex deployment's env vars carry
+// the identity of the app it belongs to (WORKOS_CLIENT_ID plus the app slug).
+// Every mutation that touches the organizations table calls this BEFORE
+// writing — if a webhook is ever delivered to the wrong deployment, the
+// mutation throws instead of silently corrupting another app's data.
+function assertOurEnvironment(): { clientId: string; appSlug: string } {
+  const clientId = process.env.WORKOS_CLIENT_ID;
+  const appSlug = process.env.NEXT_PUBLIC_PROJECT_SLUG ?? process.env.APP_SLUG;
+  if (!clientId) {
+    throw new Error(
+      'env-isolation invariant: WORKOS_CLIENT_ID env var missing in this Convex deployment',
+    );
+  }
+  if (!appSlug) {
+    throw new Error(
+      'env-isolation invariant: app slug env var missing in this Convex deployment (set APP_SLUG or NEXT_PUBLIC_PROJECT_SLUG)',
+    );
+  }
+  return { clientId, appSlug };
+}
+
 // ============================================================
 // GENERATE UPLOAD URL
 // Creates a URL for uploading a logo to Convex storage
@@ -26,6 +47,7 @@ export const saveLogo = mutation({
     storageId: v.id('_storage'),
   },
   handler: async (ctx, args) => {
+    const { clientId, appSlug } = assertOurEnvironment();
     const now = Date.now();
 
     // Check if organization exists
@@ -35,23 +57,35 @@ export const saveLogo = mutation({
       .unique();
 
     if (existing) {
+      // If the existing record was tagged for a different app, refuse to
+      // mutate it. Better to fail loudly than to silently overwrite.
+      if (existing.appSlug && existing.appSlug !== appSlug) {
+        throw new Error(
+          `env-isolation invariant: refusing to mutate org ${args.workosId} — appSlug mismatch (existing=${existing.appSlug}, current=${appSlug})`,
+        );
+      }
       // Delete old logo if exists
       if (existing.logoId) {
         await ctx.storage.delete(existing.logoId);
       }
 
-      // Update with new logo
+      // Update with new logo + lazily backfill the env-isolation fields when
+      // missing (rows created before this guard landed don't have them).
       await ctx.db.patch(existing._id, {
         logoId: args.storageId,
         updatedAt: now,
+        ...(existing.workosClientId ? {} : { workosClientId: clientId }),
+        ...(existing.appSlug ? {} : { appSlug }),
       });
 
       return existing._id;
     }
 
-    // Create new organization record
+    // Create new organization record — populate env-isolation fields.
     const id = await ctx.db.insert('organizations', {
       workosId: args.workosId,
+      workosClientId: clientId,
+      appSlug,
       logoId: args.storageId,
       createdAt: now,
       updatedAt: now,
@@ -69,6 +103,7 @@ export const saveLogo = mutation({
 export const deleteLogo = mutation({
   args: { workosId: v.string() },
   handler: async (ctx, args) => {
+    const { appSlug } = assertOurEnvironment();
     const org = await ctx.db
       .query('organizations')
       .withIndex('by_workos_id', (q) => q.eq('workosId', args.workosId))
@@ -76,6 +111,13 @@ export const deleteLogo = mutation({
 
     if (!org?.logoId) {
       return false;
+    }
+
+    // Refuse to delete data tagged for another app.
+    if (org.appSlug && org.appSlug !== appSlug) {
+      throw new Error(
+        `env-isolation invariant: refusing to delete logo for org ${args.workosId} — appSlug mismatch (existing=${org.appSlug}, current=${appSlug})`,
+      );
     }
 
     // Delete from storage

--- a/convex/functions/organizations/mutations.ts
+++ b/convex/functions/organizations/mutations.ts
@@ -3,11 +3,16 @@ import { v } from 'convex/values';
 import { mutation } from '../../_generated/server';
 
 // Per-app environment isolation guard. The Convex deployment's env vars carry
-// the identity of the app it belongs to (WORKOS_CLIENT_ID plus the app slug).
-// Every mutation that touches the organizations table calls this BEFORE
-// writing — if a webhook is ever delivered to the wrong deployment, the
-// mutation throws instead of silently corrupting another app's data.
-function assertOurEnvironment(): { clientId: string; appSlug: string } {
+// the identity of the app it belongs to. Every mutation that touches the
+// organizations table calls this BEFORE writing — if a webhook is ever
+// delivered to the wrong deployment, the mutation throws instead of silently
+// corrupting another app's data.
+//
+// WORKOS_CLIENT_ID is required (the template already requires it for auth) and
+// is the primary isolation key. The app slug is OPTIONAL extra labelling: set
+// APP_SLUG or NEXT_PUBLIC_PROJECT_SLUG to have it recorded and enforced too,
+// otherwise the slug checks are simply skipped.
+function assertOurEnvironment(): { clientId: string; appSlug: string | undefined } {
   const clientId = process.env.WORKOS_CLIENT_ID;
   const appSlug = process.env.NEXT_PUBLIC_PROJECT_SLUG ?? process.env.APP_SLUG;
   if (!clientId) {
@@ -15,12 +20,28 @@ function assertOurEnvironment(): { clientId: string; appSlug: string } {
       'env-isolation invariant: WORKOS_CLIENT_ID env var missing in this Convex deployment',
     );
   }
-  if (!appSlug) {
+  return { clientId, appSlug };
+}
+
+// Throws when an existing row is tagged as belonging to a different app.
+// Checks are presence-guarded on both sides, so rows written before this guard
+// landed (and deployments with no app slug configured) are never blocked.
+function assertRowBelongsToUs(
+  row: { workosClientId?: string; appSlug?: string },
+  env: { clientId: string; appSlug: string | undefined },
+  action: string,
+  workosId: string,
+): void {
+  if (row.workosClientId && row.workosClientId !== env.clientId) {
     throw new Error(
-      'env-isolation invariant: app slug env var missing in this Convex deployment (set APP_SLUG or NEXT_PUBLIC_PROJECT_SLUG)',
+      `env-isolation invariant: refusing to ${action} org ${workosId} — workosClientId mismatch`,
     );
   }
-  return { clientId, appSlug };
+  if (env.appSlug && row.appSlug && row.appSlug !== env.appSlug) {
+    throw new Error(
+      `env-isolation invariant: refusing to ${action} org ${workosId} — appSlug mismatch (existing=${row.appSlug}, current=${env.appSlug})`,
+    );
+  }
 }
 
 // ============================================================
@@ -47,7 +68,8 @@ export const saveLogo = mutation({
     storageId: v.id('_storage'),
   },
   handler: async (ctx, args) => {
-    const { clientId, appSlug } = assertOurEnvironment();
+    const env = assertOurEnvironment();
+    const { clientId, appSlug } = env;
     const now = Date.now();
 
     // Check if organization exists
@@ -59,11 +81,8 @@ export const saveLogo = mutation({
     if (existing) {
       // If the existing record was tagged for a different app, refuse to
       // mutate it. Better to fail loudly than to silently overwrite.
-      if (existing.appSlug && existing.appSlug !== appSlug) {
-        throw new Error(
-          `env-isolation invariant: refusing to mutate org ${args.workosId} — appSlug mismatch (existing=${existing.appSlug}, current=${appSlug})`,
-        );
-      }
+      assertRowBelongsToUs(existing, env, 'mutate', args.workosId);
+
       // Delete old logo if exists
       if (existing.logoId) {
         await ctx.storage.delete(existing.logoId);
@@ -75,7 +94,7 @@ export const saveLogo = mutation({
         logoId: args.storageId,
         updatedAt: now,
         ...(existing.workosClientId ? {} : { workosClientId: clientId }),
-        ...(existing.appSlug ? {} : { appSlug }),
+        ...(appSlug && !existing.appSlug ? { appSlug } : {}),
       });
 
       return existing._id;
@@ -85,7 +104,7 @@ export const saveLogo = mutation({
     const id = await ctx.db.insert('organizations', {
       workosId: args.workosId,
       workosClientId: clientId,
-      appSlug,
+      ...(appSlug ? { appSlug } : {}),
       logoId: args.storageId,
       createdAt: now,
       updatedAt: now,
@@ -103,7 +122,7 @@ export const saveLogo = mutation({
 export const deleteLogo = mutation({
   args: { workosId: v.string() },
   handler: async (ctx, args) => {
-    const { appSlug } = assertOurEnvironment();
+    const env = assertOurEnvironment();
     const org = await ctx.db
       .query('organizations')
       .withIndex('by_workos_id', (q) => q.eq('workosId', args.workosId))
@@ -114,11 +133,7 @@ export const deleteLogo = mutation({
     }
 
     // Refuse to delete data tagged for another app.
-    if (org.appSlug && org.appSlug !== appSlug) {
-      throw new Error(
-        `env-isolation invariant: refusing to delete logo for org ${args.workosId} — appSlug mismatch (existing=${org.appSlug}, current=${appSlug})`,
-      );
-    }
+    assertRowBelongsToUs(org, env, 'delete the logo of', args.workosId);
 
     // Delete from storage
     await ctx.storage.delete(org.logoId);

--- a/convex/tables/organizations.ts
+++ b/convex/tables/organizations.ts
@@ -13,9 +13,10 @@ import { v } from 'convex/values';
 //                    org. Mutations cross-check it against
 //                    process.env.WORKOS_CLIENT_ID before writing, so a webhook
 //                    delivered to the wrong deployment can't pollute this one.
-//   appSlug        — the app's slug, also carried in env vars and url routing.
-//                    Useful for audit logging and for maintenance scripts that
-//                    scan organizations across Convex deployments.
+//   appSlug        — the app's slug. OPTIONAL extra labelling: set APP_SLUG or
+//                    NEXT_PUBLIC_PROJECT_SLUG to have it recorded and enforced
+//                    as well. Useful for audit logging and for maintenance
+//                    scripts that scan organizations across Convex deployments.
 // Both fields are OPTIONAL, so rows created before this guard landed keep
 // validating and no backfill is required.
 // ============================================================

--- a/convex/tables/organizations.ts
+++ b/convex/tables/organizations.ts
@@ -5,11 +5,28 @@ import { v } from 'convex/values';
 // ORGANIZATIONS TABLE
 // Stores organization metadata including logos
 // WorkOS handles core org data, Convex handles extended data
+//
+// Per-app environment isolation (defense-in-depth). When several apps are
+// built from this template, each gets its own WorkOS environment and its own
+// Convex deployment. These two fields record which app owns a row:
+//   workosClientId — the WorkOS client_id of the environment that produced this
+//                    org. Mutations cross-check it against
+//                    process.env.WORKOS_CLIENT_ID before writing, so a webhook
+//                    delivered to the wrong deployment can't pollute this one.
+//   appSlug        — the app's slug, also carried in env vars and url routing.
+//                    Useful for audit logging and for maintenance scripts that
+//                    scan organizations across Convex deployments.
+// Both fields are OPTIONAL, so rows created before this guard landed keep
+// validating and no backfill is required.
 // ============================================================
 
 export const organizationsTable = defineTable({
   // WorkOS organization ID (primary key for lookups)
   workosId: v.string(),
+
+  // Per-app environment isolation (see header).
+  workosClientId: v.optional(v.string()),
+  appSlug: v.optional(v.string()),
 
   // Logo stored in Convex file storage
   logoId: v.optional(v.id('_storage')),
@@ -17,7 +34,10 @@ export const organizationsTable = defineTable({
   // Timestamps
   createdAt: v.number(),
   updatedAt: v.number(),
-}).index('by_workos_id', ['workosId']);
+})
+  .index('by_workos_id', ['workosId'])
+  // Compound index so multi-app maintenance scans can filter by app + workosId.
+  .index('by_app_workos', ['appSlug', 'workosId']);
 
 // ============================================================
 // VALIDATORS


### PR DESCRIPTION
## What

Adds per-app **environment isolation** to the `organizations` table, so a Convex deployment refuses to write rows that belong to a different app built from this template.

Two optional fields record which app owns a row:

- `workosClientId` — the WorkOS `client_id` of the environment that produced the org
- `appSlug` — the app's slug (optional, see Configuration below)

plus a `by_app_workos` compound index (`[appSlug, workosId]`) for maintenance scripts that scan organizations across deployments.

`saveLogo` and `deleteLogo` now run two guards **before** writing:

- `assertOurEnvironment()` — requires `WORKOS_CLIENT_ID` on the deployment
- `assertRowBelongsToUs()` — throws if the existing row's `workosClientId` (or `appSlug`, when configured) belongs to a different app

## Why — defense in depth

When several apps are generated from this template, each gets its own WorkOS environment and its own Convex deployment. The failure mode this guards against: a WorkOS webhook (or a misconfigured `CONVEX_URL` / deploy key) delivered to the **wrong** deployment silently writing into another app's data. Nothing in the current schema records which app a row belongs to, so such a write looks perfectly valid and corrupts data quietly.

This complements the isolation check that already exists on the session side in `src/lib/session.ts` (`session.workosClientId !== WORKOS_CLIENT_ID`) — same idea, applied at the database write path, which is where webhooks land.

Failing loudly is deliberate: silent cross-app writes are far more expensive to discover than a thrown mutation.

## Backward compatibility

- **Both fields are `v.optional(...)`.** Rows created before this change keep validating — Convex will not reject the schema push against an existing deployment, and no migration is required.
- **Lazy backfill:** `saveLogo` fills in `workosClientId` / `appSlug` on an existing row only when they are missing, so rows get tagged as they are touched rather than in a big-bang migration.
- **Mismatch checks are presence-guarded on both sides** (`if (row.workosClientId && ...)`), so untagged legacy rows are never blocked.

## Configuration

**No new configuration is required.** `WORKOS_CLIENT_ID` is the enforced isolation key, and the template already requires it for auth (`.env.example`, README).

The app slug is optional extra labelling, read from `NEXT_PUBLIC_PROJECT_SLUG ?? APP_SLUG`. If neither is set — the default for this template today — the slug is simply not written and the slug comparison is skipped; the `workosClientId` check still does the real work. Setting one of them opts into the extra tagging and the second comparison.

(An earlier revision of this branch made the slug mandatory, which would have broken `saveLogo` on any deployment that didn't set it. Fixed in 54c3aad.)

## Testing

- `bunx tsc --noEmit` — clean.
- `bunx eslint` on both changed files — clean.
- Schema change is additive and optional-only; no changes to existing call sites or queries.

Happy to adjust naming or split the two guards differently if you'd prefer a different convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9tmxZiwQB5VPV3Ax7bZa1
